### PR TITLE
Add transform functions to snapshot testing to generalise paths

### DIFF
--- a/tests/testthat/_snaps/split_combo_results.md
+++ b/tests/testthat/_snaps/split_combo_results.md
@@ -6,7 +6,7 @@
         drug_path = NA, node_col_name = "node")
     Condition
       Error:
-      ! 'C:/Users/User/Documents/Github/NANSEN/nonexistent_dir/COMBO_RUN_helper_combo_1/processed_results.csv' does not exist.
+      ! 'NANSEN/nonexistent_dir/COMBO_RUN_helper_combo_1/processed_results.csv' does not exist.
 
 # split_combo_results handles invalid network file
 
@@ -15,7 +15,7 @@
         netw_file_path = "nonexistent_network.json", drug_path = NA, node_col_name = "node")
     Condition
       Error:
-      ! 'C:/Users/User/Documents/Github/NANSEN/tests/testthat/temp_test_outputs/split_combo_test_invalid_network/COMBO_RUN_nonexistent_network/processed_results.csv' does not exist.
+      ! 'NANSEN/tests/testthat/temp_test_outputs/split_combo_test_invalid_network/COMBO_RUN_nonexistent_network/processed_results.csv' does not exist.
 
 # split_combo_results handles invalid drug file
 
@@ -25,5 +25,5 @@
         drug_path = "nonexistent_drugs.csv", node_col_name = "node")
     Condition
       Error:
-      ! 'nonexistent_drugs.csv' does not exist in current working directory ('C:/Users/User/Documents/Github/NANSEN/tests/testthat').
+      ! 'nonexistent_drugs.csv' does not exist in current working directory ('NANSEN/tests/testthat').
 

--- a/tests/testthat/test-split_combo_results.R
+++ b/tests/testthat/test-split_combo_results.R
@@ -228,7 +228,9 @@ test_that("split_combo_results handles missing files", {
       drug_path = NA,
       node_col_name = "node"
     ),
-    error = TRUE
+    error = TRUE,
+    transform = function(x) gsub(pattern = "!.+(NANSEN.+)",
+                          replacement = "! '\\1", x = x)
   )
 })
 
@@ -258,7 +260,9 @@ test_that("split_combo_results handles invalid network file", {
       drug_path = NA,
       node_col_name = "node"
     ),
-    error = TRUE
+    error = TRUE,
+    transform = function(x) gsub(pattern = "!.+(NANSEN.+)",
+                                 replacement = "! '\\1", x = x)
   )
 })
 
@@ -288,6 +292,8 @@ test_that("split_combo_results handles invalid drug file", {
       drug_path = "nonexistent_drugs.csv",
       node_col_name = "node"
     ),
-    error = TRUE
+    error = TRUE,
+    transform = function(x) gsub(pattern = "\\(.+(NANSEN.+)",
+                                 replacement = "\\('\\1", x = x)
   )
 })


### PR DESCRIPTION
Snapshot tests fail when run under a different path structure, since the snapshots of errors include literal paths:

`      ! 'C:/Users/User/Documents/Github/NANSEN/nonexistent_dir/COMBO_RUN_helper_combo_1/processed_results.csv' does not exist.`

I have added transform functions to the expect_snapshot() calls to remove the user specific part of the path, so that the snapshot does not change when a different path is used to host the repository.