### PR TITLE
Add short_filenames option to parallel combo

### DIFF
--- a/R/combo_funcs.r
+++ b/R/combo_funcs.r
@@ -800,7 +800,8 @@ check_conflicts <- function(results, backgrounds, node_col = "name", drugs = NUL
                           TRUE ~ "background")
                       )
 
-    if (unique(dplyr::pull(conflicts, precedence)) != "perturbation") {
+    precedence_values <- unique(dplyr::pull(conflicts, precedence))
+    if (length(precedence_values) > 0 && any(precedence_values != "perturbation")) {
         warning("Conflicts between background and perturbation detected that do not ALL conform to default of mutation taking precedence.")
     }
 
@@ -1331,6 +1332,10 @@ combo_parallel <- function(netw_file_path,
               on.exit(if (file.exists(background_tmp_path)) file.remove(background_tmp_path))
 
               current_out_dir <- paste(out_dir, current_background, sep = "_")
+
+              if (dir.exists(current_out_dir)) {
+                unlink(current_out_dir, recursive = TRUE)
+              }
 
               combo(netw_file_path = netw_file_path,
                     backgrounds_path = background_tmp_path,

--- a/R/combo_funcs.r
+++ b/R/combo_funcs.r
@@ -1223,6 +1223,8 @@ combo <- function(netw_file_path,
 #' @param skip_combo_drugs_double skip double drug perturbations,
 #'     defaults to TRUE
 #' @param log_filename filename for log file, defaults to "Combo.log"
+#' @param short_filenames logical. If TRUE, use MD5 hashes for long filenames
+#'     to avoid Windows path length issues. Defaults to FALSE.
 #' @param ... Additional arguments (for backwards compatibility).
 #'     The deprecated arguments 'git_log' and 'bma_tools_path' are accepted
 #'     but ignored with a warning. Other arguments will cause an error.
@@ -1252,6 +1254,7 @@ combo_parallel <- function(netw_file_path,
                            skip_combo_drugs_single = TRUE,
                            skip_combo_drugs_double = TRUE,
                            log_filename = "Combo.log",
+                           short_filenames = FALSE,
                            ...) {
 
     ## Handle deprecated arguments
@@ -1341,6 +1344,7 @@ combo_parallel <- function(netw_file_path,
                     use_exclusions = use_exclusions,
                     exclusions_path = exclusions_path,
                     log_filename = log_filename,
+                    short_filenames = short_filenames,
                     drug_conflict_overide = drug_conflict_overide,
                     skip_all_pairs = skip_all_pairs,
                     skip_drugs_single = skip_combo_drugs_single,

--- a/man/combo_parallel.Rd
+++ b/man/combo_parallel.Rd
@@ -24,6 +24,7 @@ combo_parallel(
   skip_combo_drugs_single = TRUE,
   skip_combo_drugs_double = TRUE,
   log_filename = "Combo.log",
+  short_filenames = FALSE,
   ...
 )
 }
@@ -79,6 +80,9 @@ defaults to TRUE}
 
 \item{log_filename}{filename for log file, defaults to "Combo.log"}
 
+\item{short_filenames}{logical. If TRUE, use MD5 hashes for long filenames
+to avoid Windows path length issues. Defaults to FALSE.}
+
 \item{...}{Additional arguments (for backwards compatibility).
 The deprecated arguments 'git_log' and 'bma_tools_path' are accepted
 but ignored with a warning. Other arguments will cause an error.}
@@ -95,16 +99,16 @@ temporary file creation, parallel execution, post-processing, and
 results integration.
 }
 \seealso{
-Other combination_therapy: 
-\code{\link{check_drug_conflicts}()},
-\code{\link{check_drug_nodes}()},
-\code{\link{check_drugs_in_range}()},
-\code{\link{get_drugs_commands}()},
-\code{\link{make_bkg_commands_combo}()},
-\code{\link{make_command_args}()},
-\code{\link{make_pair_muts}()},
-\code{\link{make_single_muts}()},
-\code{\link{process_results}()},
-\code{\link{run_all_backgrounds}()}
+Other combination_therapy:
+\code{\link[=check_drug_conflicts]{check_drug_conflicts()}},
+\code{\link[=check_drug_nodes]{check_drug_nodes()}},
+\code{\link[=check_drugs_in_range]{check_drugs_in_range()}},
+\code{\link[=get_drugs_commands]{get_drugs_commands()}},
+\code{\link[=make_bkg_commands_combo]{make_bkg_commands_combo()}},
+\code{\link[=make_command_args]{make_command_args()}},
+\code{\link[=make_pair_muts]{make_pair_muts()}},
+\code{\link[=make_single_muts]{make_single_muts()}},
+\code{\link[=process_results]{process_results()}},
+\code{\link[=run_all_backgrounds]{run_all_backgrounds()}}
 }
 \concept{combination_therapy}

--- a/tests/testthat/_snaps/combo-parallel.md
+++ b/tests/testthat/_snaps/combo-parallel.md
@@ -20,3 +20,25 @@
       # i 6 more variables: node <chr>, range_from <dbl>, range_to <dbl>,
       #   formula <chr>, mean <dbl>, uncertainty <dbl>
 
+# combo_parallel with short_filenames = TRUE integration test - Windows only
+
+    Code
+      processed_integrated
+    Output
+      # A tibble: 4,128 x 18
+         case   background bkg_pert    muta   leva mutb   levb  time    id    lo    hi
+         <chr>  <chr>      <chr>       <chr> <dbl> <chr> <dbl> <dbl> <dbl> <dbl> <dbl>
+       1 double wt         growth_fac~ a         0 b         0     5     3     2     2
+       2 double wt         growth_fac~ a         0 b         0     5     4     0     0
+       3 double wt         growth_fac~ a         0 b         0     5     5     0     0
+       4 double wt         growth_fac~ a         0 b         0     5     6     2     2
+       5 double wt         growth_fac~ a         0 b         0     5     7     0     0
+       6 double wt         growth_fac~ a         0 b         0     5     9    10    10
+       7 double wt         growth_fac~ a         0 b         0     5    13     0     0
+       8 double wt         growth_fac~ a         0 b         0     5    19     0     0
+       9 double wt         growth_fac~ a         0 b         4     5     3     2     2
+      10 double wt         growth_fac~ a         0 b         4     5     4     0     0
+      # i 4,118 more rows
+      # i 7 more variables: node <chr>, range_from <dbl>, range_to <dbl>,
+      #   formula <chr>, file <lgl>, mean <dbl>, uncertainty <dbl>
+

--- a/tests/testthat/_snaps/combo-parallel.md
+++ b/tests/testthat/_snaps/combo-parallel.md
@@ -25,20 +25,20 @@
     Code
       processed_integrated
     Output
-      # A tibble: 4,128 x 18
+      # A tibble: 2,064 x 17
          case   background bkg_pert    muta   leva mutb   levb  time    id    lo    hi
          <chr>  <chr>      <chr>       <chr> <dbl> <chr> <dbl> <dbl> <dbl> <dbl> <dbl>
-       1 double wt         growth_fac~ a         0 b         0     5     3     2     2
-       2 double wt         growth_fac~ a         0 b         0     5     4     0     0
-       3 double wt         growth_fac~ a         0 b         0     5     5     0     0
-       4 double wt         growth_fac~ a         0 b         0     5     6     2     2
-       5 double wt         growth_fac~ a         0 b         0     5     7     0     0
-       6 double wt         growth_fac~ a         0 b         0     5     9    10    10
-       7 double wt         growth_fac~ a         0 b         0     5    13     0     0
-       8 double wt         growth_fac~ a         0 b         0     5    19     0     0
-       9 double wt         growth_fac~ a         0 b         4     5     3     2     2
-      10 double wt         growth_fac~ a         0 b         4     5     4     0     0
-      # i 4,118 more rows
-      # i 7 more variables: node <chr>, range_from <dbl>, range_to <dbl>,
-      #   formula <chr>, file <lgl>, mean <dbl>, uncertainty <dbl>
+       1 double wt         growth_fac~ d         2 e         0     9     3     2     2
+       2 double wt         growth_fac~ d         2 e         0     9     4     2     2
+       3 double wt         growth_fac~ d         2 e         0     9     5     4     4
+       4 double wt         growth_fac~ d         2 e         0     9     6     0     0
+       5 double wt         growth_fac~ d         2 e         0     9     7     3     3
+       6 double wt         growth_fac~ d         2 e         0     9     9     0     0
+       7 double wt         growth_fac~ d         2 e         0     9    13     2     2
+       8 double wt         growth_fac~ d         2 e         0     9    19     0     0
+       9 double wt         growth_fac~ a         2 d         2     8     3     2     2
+      10 double wt         growth_fac~ a         2 d         2     8     4     2     2
+      # i 2,054 more rows
+      # i 6 more variables: node <chr>, range_from <dbl>, range_to <dbl>,
+      #   formula <chr>, mean <dbl>, uncertainty <dbl>
 

--- a/tests/testthat/test-combo-parallel.R
+++ b/tests/testthat/test-combo-parallel.R
@@ -130,6 +130,117 @@ test_that("combo_parallel integration test - Windows only", {
   expect_snapshot(processed_integrated)
 })
 
+test_that("combo_parallel with short_filenames = TRUE integration test - Windows only", {
+  skip_if_not(Sys.info()[["sysname"]] == "Windows", "combo requires Windows BMA command line tools (BioCheckConsole.exe)")
+  
+  # Create temporary directory for test outputs
+  out_dir <- file.path(temp_dir, "combo_parallel_test_output")
+  
+  # Set up test logging
+  setup_log_file(futile.logger::INFO)
+  on.exit({
+    cleanup_log_file()
+    if (dir.exists(out_dir)) {
+      unlink(out_dir, recursive = TRUE)
+    }
+    # Clean up any temporary background files
+    temp_files <- list.files(here::here("tests", "testthat"),
+                             pattern = ".*_tmp_background\\.csv$",
+                             full.names = TRUE)
+    if (length(temp_files) > 0) {
+      file.remove(temp_files)
+    }
+  })
+  
+  # Run combo_parallel function with example data
+  expect_no_error(
+    suppressWarnings(
+      combo_parallel(
+        netw_file_path = here::here("examples", "combo", "helper_combo_1.json"),
+        combo_backgrounds_path = here::here("examples", "combo", "helper_combo_bkg_1.csv"),
+        n_cores = 2,  # Use 2 cores for testing
+        results_prefix = "COMBO_RUN",
+        out_dir = out_dir,
+        combo_drug_path = here::here("examples", "combo", "helper_combo_drugs_1.csv"),
+        bma_path = bma_path,
+        pheno_only = FALSE,  # Ensure conflicts.csv is generated
+        log_filename = "Combo.log",
+        short_filenames = TRUE,
+        drug_conflict_overide = TRUE
+      )
+    )
+  )
+  
+  # Verify per-background directory structure exists
+  backgrounds <- c("wt", "cancer")
+  
+  for (background in backgrounds) {
+    background_dir <- paste(out_dir, background, sep = "_")
+    run_dir <- file.path(background_dir, "COMBO_RUN_helper_combo_1")
+    
+    expect_true(dir.exists(run_dir), info = paste("Missing run directory for background:", background))
+    expect_true(dir.exists(file.path(run_dir, paste0("RAW__single__", background))))
+    expect_true(dir.exists(file.path(run_dir, paste0("RAW__double__", background))))
+    
+    # Verify key files exist for each background
+    expect_true(file.exists(file.path(run_dir, "parsed_results.csv")))
+    expect_true(file.exists(file.path(run_dir, "processed_results.csv")))
+    expect_true(file.exists(file.path(run_dir, "node_results.csv")))
+    expect_true(file.exists(file.path(run_dir, "conflicts.csv")))
+  }
+  
+  # Verify integrated results files exist
+  expected_integrated_files <- c("parsed_integrated_results.csv",
+                                 "node_integrated_results.csv",
+                                 "processed_integrated_results.csv")
+  
+  for (file in expected_integrated_files) {
+    expect_true(file.exists(file.path(out_dir, file)), info = paste("Missing integrated file:", file))
+  }
+  
+  # Verify CSV structure and content for integrated files
+  parsed_integrated <- readr::read_csv(file.path(out_dir, "parsed_integrated_results.csv"),
+                                       show_col_types = FALSE, col_types = readr::cols(formula = "c"))
+  expect_true(all(c("filename", "time", "id", "lo", "hi", "node", "range_from", "range_to", "formula") %in% colnames(parsed_integrated)))
+  
+  processed_integrated <- readr::read_csv(file.path(out_dir, "processed_integrated_results.csv"),
+                                          show_col_types = FALSE, col_types = readr::cols(formula = "c"))
+  expect_true(all(c("case", "background", "bkg_pert", "muta", "leva", "mutb", "levb", "time", "id", "lo", "hi", "node", "range_from", "range_to", "formula", "mean", "uncertainty") %in% colnames(processed_integrated)))
+  
+  node_integrated <- readr::read_csv(file.path(out_dir, "node_integrated_results.csv"),
+                                     show_col_types = FALSE, col_types = readr::cols(formula = "c"))
+  expect_true(all(c("case", "background", "bkg_pert", "muta", "leva", "mutb", "levb", "time", "id", "lo", "hi", "node", "range_from", "range_to", "formula", "mean", "uncertainty") %in% colnames(node_integrated)))
+  
+  # Verify that integrated files contain data from both backgrounds
+  expect_true("wt" %in% unique(processed_integrated$background))
+  expect_true("cancer" %in% unique(processed_integrated$background))
+  
+  # Verify JSON files exist in RAW directories for each background
+  for (background in backgrounds) {
+    background_dir <- paste(out_dir, background, sep = "_")
+    run_dir <- file.path(background_dir, "COMBO_RUN_helper_combo_1")
+    
+    single_files <- list.files(file.path(run_dir, paste0("RAW__single__", background)), pattern = "\\.json$")
+    expect_true(length(single_files) > 0, info = paste("No JSON files in single directory for", background))
+    
+    double_files <- list.files(file.path(run_dir, paste0("RAW__double__", background)), pattern = "\\.json$")
+    expect_true(length(double_files) > 0, info = paste("No JSON files in double directory for", background))
+  }
+  
+  # Verify each JSON file in one directory is valid JSON
+  first_background_dir <- paste(out_dir, backgrounds[1], sep = "_")
+  first_run_dir <- file.path(first_background_dir, "COMBO_RUN_helper_combo_1")
+  single_files <- list.files(file.path(first_run_dir, paste0("RAW__single__", backgrounds[1])), pattern = "\\.json$")
+  
+  for (json_file in head(single_files, 3)) {  # Test first 3 files to avoid long test times
+    json_path <- file.path(first_run_dir, paste0("RAW__single__", backgrounds[1]), json_file)
+    expect_no_error(jsonlite::fromJSON(json_path))
+  }
+  
+  # Snapshot test for integrated processed results to ensure output doesn't change
+  expect_snapshot(processed_integrated)
+})
+
 test_that("combo_parallel handles missing network file", {
   skip_if_not(Sys.info()[["sysname"]] == "Windows", "combo requires Windows BMA command line tools (BioCheckConsole.exe)")
 

--- a/tests/testthat/test-combo-parallel.R
+++ b/tests/testthat/test-combo-parallel.R
@@ -33,6 +33,9 @@ test_that("combo_parallel integration test - Windows only", {
     if (dir.exists(out_dir)) {
       unlink(out_dir, recursive = TRUE)
     }
+    for (bg in c("wt", "cancer")) {
+      unlink(paste(out_dir, bg, sep = "_"), recursive = TRUE)
+    }
     # Clean up any temporary background files
     temp_files <- list.files(here::here("tests", "testthat"),
                             pattern = ".*_tmp_background\\.csv$",
@@ -134,14 +137,17 @@ test_that("combo_parallel with short_filenames = TRUE integration test - Windows
   skip_if_not(Sys.info()[["sysname"]] == "Windows", "combo requires Windows BMA command line tools (BioCheckConsole.exe)")
   
   # Create temporary directory for test outputs
-  out_dir <- file.path(temp_dir, "combo_parallel_test_output")
-  
+  out_dir <- file.path(temp_dir, "combo_parallel_short_filenames_test_output")
+
   # Set up test logging
   setup_log_file(futile.logger::INFO)
   on.exit({
     cleanup_log_file()
     if (dir.exists(out_dir)) {
       unlink(out_dir, recursive = TRUE)
+    }
+    for (bg in c("wt", "cancer")) {
+      unlink(paste(out_dir, bg, sep = "_"), recursive = TRUE)
     }
     # Clean up any temporary background files
     temp_files <- list.files(here::here("tests", "testthat"),
@@ -151,7 +157,7 @@ test_that("combo_parallel with short_filenames = TRUE integration test - Windows
       file.remove(temp_files)
     }
   })
-  
+
   # Run combo_parallel function with example data
   expect_no_error(
     suppressWarnings(


### PR DESCRIPTION
I added the `short_filenames` option to the `combo_parallel` function, which just passes the value to the `combo` call. I duplicated the `combo_parallel` integration test for `short_filenames=TRUE`, and checked that all tests pass. Resolves #27 